### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -20,6 +20,7 @@ class ProductsController < ApplicationController
 
   def show
     @product = Product.find(params[:id])
+    
   end
 
   private

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,7 +9,6 @@ class ProductsController < ApplicationController
     @products = Product.all.order(created_at: :desc)
   end
 
-
   def create
      @product = Product.new(product_params)
     if @product.save
@@ -17,6 +16,10 @@ class ProductsController < ApplicationController
     else
       render action: :new
     end
+  end
+
+  def show
+    @product = Product.find(params[:id])
   end
 
   private

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -127,7 +127,7 @@
     <ul class='item-lists'>
       <% @products.each do |product| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to product_path(product.id) do %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -20,7 +20,7 @@
         <%= "¥ #{@product.price}" %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.delivery_charge.name %>
       </span>
     </div>
 
@@ -31,8 +31,10 @@
      <% end %>
     
     <% if user_signed_in? && current_user.id != @product.user_id %>
+    <%# <% if @product.length != 0 %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
+    <%# <% end %>
     
 
     <div class="item-explain-box">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,14 +4,14 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.product_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag "item-sample.png" ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <%# <div class="sold-out"> %>
+        <%# <span>Sold Out!!</span> %>
+      <%# </div> %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
@@ -23,18 +23,15 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @product.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% end %>
+    
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>
@@ -43,11 +40,11 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category_id %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -29,9 +29,10 @@
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
      <% end %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    
+    <% if user_signed_in? && current_user.id != @product.user_id %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
     
 
     <div class="item-explain-box">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -6,8 +6,9 @@
     <h2 class="name">
       <%= @product.product_name %>
     </h2>
+
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <%# <div class="sold-out"> %>
         <%# <span>Sold Out!!</span> %>
@@ -16,7 +17,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= "¥ #{@product.price}" %>
       </span>
       <span class="item-postage">
         <%= "配送料負担" %>
@@ -27,14 +28,14 @@
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+     <% end %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-    <% end %>
     
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.product_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -44,23 +45,23 @@
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= @product.category_id %></td>
+          <td class="detail-value"><%= @product.category.name%></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.product_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.delivery_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.delivery_day.name %></td>
         </tr>
       </tbody>
     </table>
@@ -99,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>


### PR DESCRIPTION
＃WHAT
商品詳細表示機能の実装

＃WHY
商品詳細画面から購入、商品の詳細な価格などを見るため。

- ログイン状態の出品者が、自身の出品した販売中商品の詳細ページへ遷移した動画

https://user-images.githubusercontent.com/80300545/120426142-7e8da200-c3aa-11eb-978a-3516c12c3d50.mp4

- ログイン状態の出品者以外のユーザーが、他者の出品した販売中商品の詳細ページへ遷移した動画-

https://user-images.githubusercontent.com/80300545/120426180-8fd6ae80-c3aa-11eb-8c2c-22ad69b0d058.mp4

- ログアウト状態のユーザーが、商品詳細ページへ遷移した動画
- 

https://user-images.githubusercontent.com/80300545/120426201-99f8ad00-c3aa-11eb-8f47-e5d2fbf1328a.mp4

まだ、商品購入機能の実装は行っていないため、SOLDOUTや商品購入機能に紐づく処理は記載しておりません。

